### PR TITLE
Update inline part names with newly generated ContentId

### DIFF
--- a/Email.php
+++ b/Email.php
@@ -485,6 +485,8 @@ class Email extends Message
                 $attachment['inline'] = true;
                 $inlineParts[$name] = $part = $this->createDataPart($attachment);
                 $html = str_replace('cid:'.$name, 'cid:'.$part->getContentId(), $html);
+                $part->setName($part->getContentId());
+                $attachment['name'] = $part->getContentId();
                 continue 2;
             }
             $attachmentParts[] = $this->createDataPart($attachment);


### PR DESCRIPTION
Inline parts are identified by matching attachment names to cids found in the html part. In line 487 cids are regenerated and replaced in the html part, but the attachment names are not similarly replaced. This change fixes that.