### PR TITLE
Email image parts: regex for single closing quotes

### DIFF
--- a/Email.php
+++ b/Email.php
@@ -490,8 +490,8 @@ class Email extends Message
             $html = $htmlPart->getBody();
 
             $regexes = [
-                '<img\s+[^>]*src\s*=\s*(?:([\'"])cid:([^"]+)\\1|cid:([^>\s]+))',
-                '<\w+\s+[^>]*background\s*=\s*(?:([\'"])cid:([^"]+)\\1|cid:([^>\s]+))',
+                '<img\s+[^>]*src\s*=\s*(?:([\'"])cid:([^\'"]+)\\1|cid:([^>\s]+))',
+                '<\w+\s+[^>]*background\s*=\s*(?:([\'"])cid:([^\'"]+)\\1|cid:([^>\s]+))',
             ];
             $tmpMatches = [];
             foreach ($regexes as $regex) {


### PR DESCRIPTION
The regex for image `src` does match for single and double opening quotes:
`([\'"])`

The corresponding matching for non-closing characters is implemented for double quotes only:
`([^"]+)`
This change adds single quotes to the regex:
`([^\'"]+)`

---

And with a non-greedy regex we might go for something like this:
`([\'"])cid:(.+?)\\1`
instead of
`([\'"])cid:([^\'"]+)\\1`