### PR TITLE
Upgrade Email-Validator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/polyfill-mbstring": "^1.0"
     },
     "require-dev": {
-        "egulias/email-validator": "^2.1.10|^3.1",
+        "egulias/email-validator": "^3.1|^4.0",
         "league/html-to-markdown": "^5.0",
         "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
         "symfony/dependency-injection": "^5.4|^6.0",


### PR DESCRIPTION
Drop support for outdated version 2.1 and add support for newer one (4.0).

See https://github.com/egulias/EmailValidator#supported-versions