### PR TITLE
Add getDispostion() in TextPart to get current content disposition

### DIFF
--- a/Part/TextPart.php
+++ b/Part/TextPart.php
@@ -95,6 +95,16 @@ class TextPart extends AbstractPart
 
         return $this;
     }
+    
+    /**
+     * Gets the current content disposition
+     *
+     * @return string Current content disposition
+     */
+    public function getDisposition(): string
+    {
+        return $this->disposition;
+    }
 
     /**
      * Sets the name of the file (used by FormDataPart).


### PR DESCRIPTION
It would be nice to get the current content disposition in TextPart. This is needed to determine if an attachment is inline or not.