### PR TITLE
update the FROM_STRING_PATTERN inside Address.php

### DIFF
--- a/Address.php
+++ b/Address.php
@@ -31,7 +31,7 @@ final class Address
      * config, and allows to have more readable config.
      * This does not try to cover all edge cases for address.
      */
-    private const FROM_STRING_PATTERN = '~(?<displayName>[^<]*)<(?<addrSpec>.*)>[^>]*~';
+    private const FROM_STRING_PATTERN = '~(?<displayName>.*)?<(?<addrSpec>.*)>[^>]*~';
 
     private static EmailValidator $validator;
     private static IdnAddressEncoder $encoder;


### PR DESCRIPTION
Fixes the `FROM_STRING_PATTERN` inside Address.php.

As it is right now strings with the character inside the display name "<" will not parse correctly. For example the string "Andre Hoong <3 <hoongandre@gmail.com>"  will have the following matches returned using the current pattern:
displayName => Andre Hoong
addrSpec => 3 <hoongandre@gmail.com

The new string pattern '~(?<displayName>.*)?<(?<addrSpec>.*)>[^>]*~' allows the displayName to include the "<" character and correctly parses the addrSpec. It does this by taking the last occurence of the "<" to singal the start of the addrSpec