### PR TITLE
Make RawMessage::message nullable in the constructor

### DIFF
--- a/RawMessage.php
+++ b/RawMessage.php
@@ -21,7 +21,7 @@ class RawMessage
     private iterable|string|null $message = null;
     private bool $isGeneratorClosed;
 
-    public function __construct(iterable|string $message)
+    public function __construct(iterable|string|null $message)
     {
         $this->message = $message;
     }


### PR DESCRIPTION
The underlying backing field is nullable. However the parameter passed to the constructor is not. This PR proposes to keep them in sync. 

One motivation is that currently `ConstructorExtractor` extracts an incomplete set of types.